### PR TITLE
Improve mobile interaction for iPod wheel

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -210,6 +210,7 @@ body{
   margin:32px auto 0;
   position:relative;
   cursor: grab; /* Moved cursor style here */
+  touch-action: none; /* Allow custom handling of touch drag */
 }
 #wheel .label{
   position:absolute;
@@ -270,4 +271,11 @@ body{
   height:100%;
   border-radius:50%;
   pointer-events: none; /* Allow clicks and drags to pass through */
+}
+
+@media (max-width: 400px) {
+  #ipod {
+    width: 90vw;
+    height: calc(90vw * 1.8);
+  }
 }

--- a/js/script.js
+++ b/js/script.js
@@ -212,22 +212,25 @@
 
   /* --- wheel rotation --- */
   const wheelElement = document.getElementById("wheel");
-  wheelElement.addEventListener("mousedown", (e) => {
+
+  function startDrag(e) {
     if (e.target !== document.getElementById("button-center") && currentView !== "nowplaying") {
       dragging = true;
       lastAngle = getAngle(e);
       wheelElement.style.cursor = "grabbing";
     }
-  });
-  window.addEventListener("mouseup", () => {
+  }
+
+  function endDrag() {
     if (dragging) {
       dragging = false;
       lastAngle = null;
       accum = 0;
       wheelElement.style.cursor = "grab";
     }
-  });
-  window.addEventListener("mousemove", (e) => {
+  }
+
+  function moveDrag(e) {
     if (!dragging || currentView === "nowplaying") return;
     const ang = getAngle(e);
     if (lastAngle !== null) {
@@ -255,7 +258,12 @@
       }
     }
     lastAngle = ang;
-  });
+  }
+
+  // Pointer events for mouse and touch interaction
+  wheelElement.addEventListener("pointerdown", startDrag);
+  window.addEventListener("pointerup", endDrag);
+  window.addEventListener("pointermove", moveDrag);
   function getAngle(e) {
     const r = wheelElement.getBoundingClientRect();
     const cx = r.left + r.width / 2,


### PR DESCRIPTION
## Summary
- allow touch interactions by using pointer events on the scroll wheel
- disable native scrolling on the wheel
- scale iPod layout for small screens

## Testing
- `node --check js/script.js`

------
https://chatgpt.com/codex/tasks/task_e_6844fa47b96c83318222ee44fc22069a